### PR TITLE
Change Webb and WebbUtils to provide a protected constructor.

### DIFF
--- a/src/main/java/com/goebl/david/Webb.java
+++ b/src/main/java/com/goebl/david/Webb.java
@@ -50,7 +50,7 @@ public class Webb {
     HostnameVerifier hostnameVerifier;
     RetryManager retryManager;
 
-    private Webb() {}
+    protected Webb() {}
 
     /**
      * Create an instance which can be reused for multiple requests in the same Thread.

--- a/src/main/java/com/goebl/david/WebbUtils.java
+++ b/src/main/java/com/goebl/david/WebbUtils.java
@@ -31,7 +31,7 @@ import java.util.zip.InflaterInputStream;
  */
 public class WebbUtils {
 
-    private WebbUtils() {}
+    protected WebbUtils() {}
 
     /**
      * Convert a Map to a query string.


### PR DESCRIPTION
Private constructor does not allow these classes to be inherited.

There are valid cases for extending the behaviour, but having a
private constructor does not allow it.
