### PR TITLE
#18: Allow to get the result as InputStream

### DIFF
--- a/src/main/java/com/goebl/david/Request.java
+++ b/src/main/java/com/goebl/david/Request.java
@@ -399,6 +399,14 @@ public class Request {
     }
 
     /**
+     * Execute the request and expect the result to be convertible to <code>InputStream</code>.
+     * @return the created <code>Response</code> object carrying the payload from the server as <code>InputStream</code>
+     */
+    public Response<InputStream> asStream() {
+        return webb.execute(this, InputStream.class);
+    }
+
+    /**
      * Execute the request and expect no result payload (only status-code and headers).
      * @return the created <code>Response</code> object where no payload is expected or simply will be ignored.
      */

--- a/src/test/java/com/goebl/david/TestWebb_UpDownload.java
+++ b/src/test/java/com/goebl/david/TestWebb_UpDownload.java
@@ -1,10 +1,11 @@
 package com.goebl.david;
 
-import org.json.JSONArray;
-
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.util.Random;
-import java.util.zip.GZIPInputStream;
+import org.json.JSONArray;
 
 public class TestWebb_UpDownload extends AbstractTestWebb {
     private static File TEST_FILE;
@@ -185,5 +186,20 @@ public class TestWebb_UpDownload extends AbstractTestWebb {
                 .asBytes();
 
         assertArrayEquals(msg, response.getBody());
+    }
+
+    public void testEchoAsStream() throws Exception {
+        byte[] msg = (SIMPLE_ASCII + ", " + COMPLEX_UTF8).getBytes(Const.UTF8);
+        Response<InputStream> response = webb
+                .post("/echoBin")
+                .body(msg)
+                .asStream();
+        InputStream is = response.getBody();
+        try {
+            byte[] result = WebbUtils.readBytes(is);
+            assertArrayEquals(msg, result);
+        } finally {
+            is.close();
+        }
     }
 }


### PR DESCRIPTION
Fix for https://github.com/hgoebl/DavidWebb/issues/18

The goal of this PR is to allow to get the result as an InputStream by adding a new method called asStream in the class Request.