### PR TITLE
Provide the JSON library as a provided dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20080701</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/com/goebl/david/AbstractTestWebb.java
+++ b/src/test/java/com/goebl/david/AbstractTestWebb.java
@@ -22,13 +22,18 @@ public abstract class AbstractTestWebb extends TestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        String host = isAndroid()
-                ? (isEmulator() ? "10.0.2.2" : HOST_IP)
-                : "localhost";
+        String host = getHost();
 
         Webb.setGlobalHeader(Webb.HDR_USER_AGENT, Webb.DEFAULT_USER_AGENT);
         webb = Webb.create();
         webb.setBaseUri("http://" + host + ":3003");
+    }
+
+    protected String getHost() {
+        String host = isAndroid()
+                ? (isEmulator() ? "10.0.2.2" : HOST_IP)
+                : "localhost";
+        return host;
     }
 
     protected void assertArrayEquals(byte[] expected, byte[] bytes) {

--- a/src/test/java/com/goebl/david/TestWebb_Ssl.java
+++ b/src/test/java/com/goebl/david/TestWebb_Ssl.java
@@ -42,7 +42,7 @@ public class TestWebb_Ssl extends AbstractTestWebb {
         webb.setHostnameVerifier(new TrustingHostnameVerifier());
 
         // www.wellcrafted.de has same IP as www.goebl.com, but certificate is for www.goebl.com
-        Response<Void> response = webb.get("https://localhost:13003/").asVoid();
+        Response<Void> response = webb.get("https://" + getHost() + ":13003/").asVoid();
         assertTrue(response.isSuccess());
     }
 
@@ -56,7 +56,7 @@ public class TestWebb_Ssl extends AbstractTestWebb {
         webb.setSSLSocketFactory(sslContext.getSocketFactory());
         webb.setHostnameVerifier(new TrustingHostnameVerifier());
 
-        Response<Void> response = webb.get("https://localhost:13003/").asVoid();
+        Response<Void> response = webb.get("https://" + getHost() + ":13003/").asVoid();
         assertTrue(response.isSuccess() || response.getStatusCode() == 301);
     }
 


### PR DESCRIPTION
I replaced the scope on the JSON library to the 'provided' scope, since the same org.json API is available from Android.

Almost all the tests passed on my local machine's JVM and the Android device, but I did have to tell the Android device where to find the testing server.

The one test that fails after these changes is com.goebl.david.TestWebb_Ssl.testHttpsInvalidCertificate, which fails due to "junit.framework.AssertionFailedError: expected:<class java.io.IOException> but was:<class javax.net.ssl.SSLPeerUnverifiedException>". I ran the test on a device running Android 6.0.1. Perhaps the Android system is more explicit about what exceptions it throws when it encounters an invalid certificate than it was in older versions of Android? Alternatively, maybe that specific test can be changed to check if the thrown exception is a descendant class of IOException. Any thoughts?